### PR TITLE
Use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-secrets-manager-action",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-secrets-manager-action",
-      "version": "2.0.0-rc1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",


### PR DESCRIPTION
Node version 12 is depreciated as of https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

This changes this to run on node 16 instead.